### PR TITLE
Add Playwright browser caching to CI workflow

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -24,7 +24,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run API tests


### PR DESCRIPTION
## Summary
- Add caching for Playwright browser installation to speed up CI runs
- Cache key is based on Playwright version to ensure cache invalidation when version changes
- Only install browsers if cache miss occurs

## Changes
- Added step to get Playwright version
- Added cache action for `~/.cache/ms-playwright` directory  
- Made browser installation conditional on cache miss

This will significantly reduce CI run times by avoiding repeated browser downloads.